### PR TITLE
fix: update version to match with release tag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "overtls"
-version = "0.2.25"
+version = "0.2.26"
 edition = "2021"
 license = "MIT"
 description = "A simple proxy tunnel, minimalist tool for bypassing the GFW."


### PR DESCRIPTION
update version to match with the release tag

- https://github.com/Homebrew/homebrew-core/pull/173437